### PR TITLE
#44 Updating dependencies. The '@ty-ras/endpoint'…

### DIFF
--- a/metadata-jsonschema/package.json
+++ b/metadata-jsonschema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ty-ras/metadata-jsonschema",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "author": {
     "name": "Stanislav Muhametsin",
     "email": "346799+stazz@users.noreply.github.com",

--- a/metadata/package.json
+++ b/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ty-ras/metadata",
-  "version": "0.12.5",
+  "version": "0.13.0",
   "author": {
     "name": "Stanislav Muhametsin",
     "email": "346799+stazz@users.noreply.github.com",
@@ -21,7 +21,7 @@
   "module": "",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "@ty-ras/endpoint": "0.12.7"
+    "@ty-ras/data-backend": "0.13.0"
   },
   "devDependencies": {
     "@babel/core": "7.19.3",

--- a/metadata/src/provider.d.ts
+++ b/metadata/src/provider.d.ts
@@ -1,4 +1,5 @@
-import type * as data from "@ty-ras/data-backend";
+import type * as data from "@ty-ras/data";
+import type * as dataBE from "@ty-ras/data-backend";
 import type * as common from "./common";
 import type * as endpoint from "./endpoint";
 
@@ -8,8 +9,8 @@ export type MetadataProvider<
   TEndpointMD,
   TStringDecoder,
   TStringEncoder,
-  TOutputContents extends data.TOutputContentsBase,
-  TInputContents extends data.TInputContentsBase,
+  TOutputContents extends dataBE.TOutputContentsBase,
+  TInputContents extends dataBE.TInputContentsBase,
   TStateMD,
   TFinalMetadataArgs,
   TFinalMetadata,
@@ -37,8 +38,8 @@ export interface MetadataProviderForEndpoints<
   TEndpointMD,
   TStringDecoder,
   TStringEncoder,
-  TOutputContents extends data.TOutputContentsBase,
-  TInputContents extends data.TInputContentsBase,
+  TOutputContents extends dataBE.TOutputContentsBase,
+  TInputContents extends dataBE.TInputContentsBase,
 > {
   getEndpointsMetadata: endpoint.GetEndpointsMetadata<
     TArgument,

--- a/metadata/src/provider.d.ts
+++ b/metadata/src/provider.d.ts
@@ -1,5 +1,4 @@
 import type * as data from "@ty-ras/data-backend";
-import type * as ep from "@ty-ras/endpoint";
 import type * as common from "./common";
 import type * as endpoint from "./endpoint";
 
@@ -27,7 +26,7 @@ export type MetadataProvider<
     args: TFinalMetadataArgs,
     endpointsMetadatas: ReadonlyArray<{
       md: TEndpointMD;
-      stateMD: Partial<Record<ep.HttpMethod, TStateMD>>;
+      stateMD: Partial<Record<data.HttpMethod, TStateMD>>;
     }>,
   ) => TFinalMetadata;
 };

--- a/metadata/yarn.lock
+++ b/metadata/yarn.lock
@@ -350,24 +350,17 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
-"@ty-ras/data-backend@0.12.4":
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/@ty-ras/data-backend/-/data-backend-0.12.4.tgz#d29c106a9aab73181683d2b3717e47f88e38168a"
-  integrity sha512-v2B9jmsSjnqs3a4+K/l4yfdI5cmcvQdln4nNuEHjakcJrNBkLIsbEfQeBE2ptw8HskbLEiLZ+9G1jUl9b2Uweg==
+"@ty-ras/data-backend@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@ty-ras/data-backend/-/data-backend-0.13.0.tgz#dc45ad57107474cd1b663711fce473c4202df120"
+  integrity sha512-kn0OZe9Ns01DIhFl4dJniXuKryZNPYZXI2IDL/LQc0vmHsYrwYqNrUuDcUsinR3nweh0sZxyzKhbpvUil49tmw==
   dependencies:
-    "@ty-ras/data" "0.12.3"
+    "@ty-ras/data" "0.13.0"
 
-"@ty-ras/data@0.12.3":
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/@ty-ras/data/-/data-0.12.3.tgz#89f50dab7180906ba8aa7e8930c5a0ccea5f2132"
-  integrity sha512-MW0TNixdi4fbqWsJAtUNPSxvGVn8YhkX2Y9RAOd/HxlJ/nrRn1CQLU2qCis5Zky7Xkc519WPJTr7+tmUer1alA==
-
-"@ty-ras/endpoint@0.12.7":
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/@ty-ras/endpoint/-/endpoint-0.12.7.tgz#f34f07c656a5379e5e1ad2af58cb808d10d8f8b7"
-  integrity sha512-Nd78EXmcZVO+95BYuViEBxIty02K+82NkmeI08HJASaCYkH6/DCG9fJ9gAAfGeO0o52RlWc+eJM1ayMoPm8UeA==
-  dependencies:
-    "@ty-ras/data-backend" "0.12.4"
+"@ty-ras/data@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@ty-ras/data/-/data-0.13.0.tgz#45acb046958350de01916f2cb433ec9da165abef"
+  integrity sha512-AZYCdMiBPTO4+V0Apg+i9XUo17c4C5Up+0O8Jk8cBYVCm/4W5kbzGdcE40GKNFqkn71IVrfjv5GAaMpg5EbFXg==
 
 "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"


### PR DESCRIPTION
… is no longer needed, instead we can just use
'@ty-ras/data-backend', since HTTP method types are exported by '@ty-ras/data'.